### PR TITLE
Route WORK thumbnails into embedded live project sites

### DIFF
--- a/scripts/verify-projects-detail.mjs
+++ b/scripts/verify-projects-detail.mjs
@@ -1,0 +1,122 @@
+/* Verifies the WORK projects now route into on-site detail pages that embed
+ * the live Vercel deployment, instead of linking out to Frontend Mentor.
+ * Requires the dev server running (BASE, default http://localhost:3000). */
+import { mkdirSync } from "node:fs";
+import { chromium } from "playwright";
+
+const BASE = process.env.BASE ?? "http://localhost:3000";
+const SHOTS = ".project-shots";
+mkdirSync(SHOTS, { recursive: true });
+
+// Mirror of the relevant fields in PROJECTS (src/shared/lib/constants.ts).
+const PROJECTS = [
+  { slug: "bookmark-landing-page", title: "Bookmark Landing Page", liveUrl: "https://bookmark-landing-page-jade-gamma.vercel.app" },
+  { slug: "room-homepage", title: "Room Homepage", liveUrl: "https://room-homepage-rust-mu.vercel.app" },
+  { slug: "loopstudio-landing-page", title: "Loopstudio Landing Page", liveUrl: "https://loopstudios-landing-page-lovat.vercel.app" },
+  { slug: "nft-card-component", title: "NFT Card Component", liveUrl: "https://nft-preview-card-beta-kohl.vercel.app" },
+  { slug: "password-generator-app", title: "Password Generator App", liveUrl: "https://password-generator-six-alpha.vercel.app" },
+  { slug: "frontend-quiz-app", title: "Frontend Quiz App", liveUrl: "https://quiz-app-jet-three.vercel.app" },
+  { slug: "tip-calculator-app", title: "Tip Calculator App", liveUrl: "https://tip-calculator-pearl-iota.vercel.app" },
+  { slug: "time-tracking-dashboard", title: "Time Tracking Dashboard", liveUrl: "https://time-tracking-dashboard-three-phi.vercel.app" },
+];
+
+const browser = await chromium.launch();
+const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+const page = await context.newPage();
+const failures = [];
+const check = (name, ok) => {
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}`);
+  if (!ok) failures.push(name);
+};
+
+// Never let any page navigate the top frame to Frontend Mentor.
+let femRequest = false;
+page.on("request", (req) => {
+  if (req.isNavigationRequest() && req.url().includes("frontendmentor.io")) {
+    femRequest = true;
+  }
+});
+
+// --- 1. Home grid links internally, not out ---
+await page.goto(`${BASE}/`, { waitUntil: "networkidle" });
+const homeLink = page.locator(`a[href="/projects/${PROJECTS[0].slug}"]`).first();
+check("home thumbnail links to /projects/{slug}", (await homeLink.count()) > 0);
+check("home thumbnail is not target=_blank", (await homeLink.getAttribute("target")) === null);
+check("no frontendmentor.io links on home", (await page.locator('a[href*="frontendmentor.io"]').count()) === 0);
+
+// --- 2. /projects grid links internally ---
+await page.goto(`${BASE}/projects`, { waitUntil: "networkidle" });
+for (const p of PROJECTS) {
+  const link = page.locator(`a[href="/projects/${p.slug}"]`).first();
+  check(`/projects links to ${p.slug}`, (await link.count()) > 0);
+}
+check("no frontendmentor.io links on /projects", (await page.locator('a[href*="frontendmentor.io"]').count()) === 0);
+
+// --- 3. Click a thumbnail → stays on-site, lands on detail ---
+await page.locator(`a[href="/projects/${PROJECTS[0].slug}"]`).first().click();
+await page.waitForURL(`**/projects/${PROJECTS[0].slug}`);
+check("click keeps host on localhost", new URL(page.url()).host === new URL(BASE).host);
+
+// --- 4. Every detail page: title, embedded iframe = liveUrl, open-full-site link ---
+for (const p of PROJECTS) {
+  await page.goto(`${BASE}/projects/${p.slug}`, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("main h1");
+  check(`${p.slug}: h1 shows title`, (await page.locator("main h1").innerText()).includes(p.title));
+
+  // Iframe is lazy; scroll it into view then wait for it to mount.
+  await page.locator("iframe").scrollIntoViewIfNeeded().catch(() => {});
+  await page.waitForSelector("iframe", { timeout: 10000 });
+  const iframeSrc = await page.locator("iframe").first().getAttribute("src");
+  check(`${p.slug}: iframe src is the live Vercel URL`, iframeSrc === p.liveUrl);
+
+  const openFull = page.locator(`a[href="${p.liveUrl}"][target="_blank"]`);
+  check(`${p.slug}: "open full site" link present`, (await openFull.count()) > 0);
+}
+
+// --- 5. Embedded live sites actually load (not framing-blocked) ---
+for (const p of PROJECTS) {
+  await page.goto(`${BASE}/projects/${p.slug}`, { waitUntil: "domcontentloaded" });
+  await page.locator("iframe").scrollIntoViewIfNeeded().catch(() => {});
+  const handle = await page.waitForSelector("iframe", { timeout: 10000 });
+  // contentFrame() resolves only if the browser actually rendered the framed doc.
+  const frame = await handle.contentFrame();
+  let loaded = false;
+  if (frame) {
+    try {
+      await frame.waitForLoadState("domcontentloaded", { timeout: 15000 });
+      loaded = true;
+    } catch {
+      loaded = false;
+    }
+  }
+  check(`${p.slug}: embedded live site loads (not blocked)`, loaded);
+}
+
+// --- 6. No horizontal overflow at desktop + mobile ---
+await page.goto(`${BASE}/projects/${PROJECTS[0].slug}`, { waitUntil: "networkidle" });
+const overflow1280 = await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1);
+check("no horizontal overflow @1280", !overflow1280);
+await page.screenshot({ path: `${SHOTS}/detail-desktop.png`, fullPage: true });
+
+await page.setViewportSize({ width: 390, height: 844 });
+await page.goto(`${BASE}/projects/${PROJECTS[0].slug}`, { waitUntil: "networkidle" });
+const overflow390 = await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1);
+check("no horizontal overflow @390", !overflow390);
+await page.screenshot({ path: `${SHOTS}/detail-mobile.png`, fullPage: true });
+await page.setViewportSize({ width: 1280, height: 900 });
+
+// --- 7. Prev/next navigation ---
+await page.goto(`${BASE}/projects/${PROJECTS[0].slug}`, { waitUntil: "domcontentloaded" });
+await page.locator('nav[aria-label="Project navigation"] a').last().click();
+await page.waitForURL(`**/projects/${PROJECTS[1].slug}`);
+check("prev/next nav navigates between projects", page.url().endsWith(`/projects/${PROJECTS[1].slug}`));
+
+check("no top-frame navigation to Frontend Mentor occurred", !femRequest);
+
+await browser.close();
+
+if (failures.length > 0) {
+  console.error(`\n${failures.length} failure(s):\n  ${failures.join("\n  ")}`);
+  process.exit(1);
+}
+console.log("\nAll checks passed.");

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,0 +1,151 @@
+import { notFound } from "next/navigation";
+import { Link } from "next-view-transitions";
+
+import { ArrowUpRight, Github } from "lucide-react";
+
+import { SandboxFrame } from "@/features/lab/sandbox-frame";
+import { PROJECTS } from "@/shared/lib/constants";
+import Container from "@/shared/layout/container";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export function generateStaticParams() {
+  return PROJECTS.map((project) => ({ slug: project.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params;
+  const project = PROJECTS.find((p) => p.slug === slug);
+  if (!project) return {};
+
+  return {
+    title: `${project.title} | Work`,
+    description: project.description,
+  };
+}
+
+export default async function ProjectPage({ params }: PageProps) {
+  const { slug } = await params;
+  const index = PROJECTS.findIndex((p) => p.slug === slug);
+  if (index === -1) notFound();
+
+  const project = PROJECTS[index];
+  const prev = PROJECTS[index - 1];
+  const next = PROJECTS[index + 1];
+
+  return (
+    <Container className="pt-8 pb-20">
+      <header className="mb-8">
+        <Link
+          href="/#projects"
+          className="mb-6 inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-primary"
+        >
+          ← Back to work
+        </Link>
+
+        <div className="flex flex-wrap items-baseline justify-between gap-x-6 gap-y-2">
+          <h1 className="text-balance text-3xl font-bold tracking-tighter sm:text-4xl">
+            {project.title}
+          </h1>
+          <div className="flex flex-wrap items-center gap-2">
+            {project.tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full border border-border px-2.5 py-0.5 font-mono text-[11px] uppercase tracking-wide text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <p className="mt-3 max-w-2xl text-pretty text-lg text-muted-foreground">
+          {project.description}
+        </p>
+      </header>
+
+      {/* Live embed of the deployed site */}
+      <div className="overflow-hidden rounded-sm border border-border bg-card">
+        <div
+          className="relative h-[480px] overflow-hidden sm:h-[620px]"
+          style={{ viewTransitionName: `projects-canvas-${project.slug}` }}
+        >
+          <SandboxFrame
+            src={project.liveUrl}
+            title={project.title}
+            scale={0.55}
+            sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals"
+          />
+        </div>
+        <div className="flex items-center justify-between gap-4 border-t border-border px-4 py-2">
+          <span className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+            Live preview
+          </span>
+          <a
+            href={project.liveUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-sm font-medium text-foreground transition-colors hover:text-primary"
+          >
+            Open full site
+            <ArrowUpRight aria-hidden className="size-3.5" />
+            <span className="sr-only">(opens in a new tab)</span>
+          </a>
+        </div>
+      </div>
+
+      {project.repoUrl && (
+        <p className="mt-6 text-sm text-muted-foreground">
+          <a
+            href={project.repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:text-primary hover:decoration-primary"
+          >
+            <Github aria-hidden className="size-3.5" />
+            View source on GitHub
+          </a>
+        </p>
+      )}
+
+      {/* Prev / next project */}
+      <nav
+        aria-label="Project navigation"
+        className="mt-12 flex items-stretch justify-between gap-4 border-t border-border pt-6"
+      >
+        {prev ? (
+          <Link
+            href={`/projects/${prev.slug}`}
+            className="group min-w-0 text-left transition-colors hover:text-primary"
+          >
+            <span className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+              ← Previous
+            </span>
+            <span className="mt-0.5 block truncate text-sm font-medium">
+              {prev.title}
+            </span>
+          </Link>
+        ) : (
+          <span />
+        )}
+        {next ? (
+          <Link
+            href={`/projects/${next.slug}`}
+            className="group min-w-0 text-right transition-colors hover:text-primary"
+          >
+            <span className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">
+              Next →
+            </span>
+            <span className="mt-0.5 block truncate text-sm font-medium">
+              {next.title}
+            </span>
+          </Link>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </Container>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,9 +1,9 @@
 import Container from "@/shared/layout/container";
 import { Card } from "@/shared/components/card";
 import { PROJECTS } from "@/shared/lib/constants";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "next-view-transitions";
 
 export const metadata = {
   title: "Work | Robert Crocker",
@@ -39,15 +39,13 @@ export default function ProjectsPage() {
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {PROJECTS.map((project) => (
           <Card
-            key={project.link}
+            key={project.slug}
             className="ring-2 ring-transparent ring-offset-1 transition-all duration-200 group focus-within:ring-primary hover:ring-primary"
           >
             <Link
-              href={project.link}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={`/projects/${project.slug}`}
               className="block overflow-hidden relative w-full h-48 rounded focus-visible:outline-none"
-              aria-label={`View ${project.title} on Frontend Mentor (opens in new tab)`}
+              aria-label={`View ${project.title} details`}
               title={project.title}
             >
               <Image
@@ -58,11 +56,12 @@ export default function ProjectsPage() {
                 sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                 style={{
                   objectFit: "cover",
+                  viewTransitionName: `projects-canvas-${project.slug}`,
                 }}
               />
-              {/* External link indicator */}
+              {/* View-details indicator */}
               <div className="absolute right-3 top-3 rounded-full bg-primary p-1.5 text-primary-foreground opacity-0 shadow backdrop-blur-sm transition-opacity group-hover:opacity-100">
-                <ArrowUpRight className="w-4 h-4" />
+                <ArrowRight className="w-4 h-4" />
               </div>
             </Link>
           </Card>

--- a/src/features/home/sections/project-section.tsx
+++ b/src/features/home/sections/project-section.tsx
@@ -2,9 +2,9 @@
 
 import { Card } from "@/shared/components/card";
 import { NAVIGATION_ITEMS, PROJECTS } from "@/shared/lib/constants";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "next-view-transitions";
 
 const DISPLAY_COUNT = 6;
 
@@ -45,16 +45,14 @@ export default function ProjectsSection() {
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {displayedProjects.map((project, index) => (
           <Card
-            key={project.link}
+            key={project.slug}
             id={`project-${index}`}
             className="ring-2 ring-transparent ring-offset-1 transition-all duration-200 group hover:ring-primary focus-within:ring-primary"
           >
             <Link
-              href={project.link}
-              target="_blank"
-              rel="noopener noreferrer"
+              href={`/projects/${project.slug}`}
               className="block overflow-hidden relative z-0 w-full h-48 rounded focus-visible:outline-none"
-              aria-label={`View ${project.title} on Frontend Mentor (opens in new tab)`}
+              aria-label={`View ${project.title} details`}
               title={project.title}
             >
               <Image
@@ -65,11 +63,12 @@ export default function ProjectsSection() {
                 sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                 style={{
                   objectFit: "cover",
+                  viewTransitionName: `projects-canvas-${project.slug}`,
                 }}
               />
-              {/* External link indicator */}
+              {/* View-details indicator */}
               <div className="absolute top-3 text-primary-foreground right-3 p-1.5 bg-primary backdrop-blur-sm rounded-full opacity-0 group-hover:opacity-100 transition-opacity shadow">
-                <ArrowUpRight className="w-4 h-4" />
+                <ArrowRight className="w-4 h-4" />
               </div>
             </Link>
           </Card>

--- a/src/features/lab/sandbox-frame.tsx
+++ b/src/features/lab/sandbox-frame.tsx
@@ -11,6 +11,12 @@ interface SandboxFrameProps {
    * viewport so nothing overflows the fixed-height tile.
    */
   scale?: number;
+  /**
+   * Overrides the iframe sandbox allow-list. Defaults to the value the
+   * Lab demos rely on; embedded full sites (forms, clipboard, popups)
+   * pass a broader list.
+   */
+  sandbox?: string;
 }
 
 /**
@@ -19,7 +25,12 @@ interface SandboxFrameProps {
  * on page load. Once mounted it stays mounted — browsers throttle
  * offscreen iframes, and remounting would flash a reload.
  */
-export function SandboxFrame({ src, title, scale = 1 }: SandboxFrameProps) {
+export function SandboxFrame({
+  src,
+  title,
+  scale = 1,
+  sandbox = "allow-scripts allow-same-origin",
+}: SandboxFrameProps) {
   const ref = useRef<HTMLDivElement>(null);
   const [mounted, setMounted] = useState(false);
 
@@ -52,7 +63,7 @@ export function SandboxFrame({ src, title, scale = 1 }: SandboxFrameProps) {
           src={src}
           title={title}
           className="relative border-0"
-          sandbox="allow-scripts allow-same-origin"
+          sandbox={sandbox}
           style={{
             width: inverse,
             height: inverse,

--- a/src/shared/lib/constants.ts
+++ b/src/shared/lib/constants.ts
@@ -28,7 +28,14 @@ export interface Project {
   description: string;
   tags: string[];
   image: string;
-  link: string;
+  /** URL-safe id that drives the /projects/[slug] detail route */
+  slug: string;
+  /** Deployed Vercel URL — embedded in the detail page iframe and the "open full site" link */
+  liveUrl: string;
+  /** GitHub repo, surfaced as an optional "view source" link */
+  repoUrl?: string;
+  /** Original Frontend Mentor solution page, kept for reference */
+  link?: string;
 }
 
 export const PROJECTS: Project[] = [
@@ -38,6 +45,9 @@ export const PROJECTS: Project[] = [
       "This challenge will really test your layout skills. There are also areas that will require some JavaScript, such as the tabbed features section and the FAQ accordion.",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/bookmark_landing_page.png",
+    slug: "bookmark-landing-page",
+    liveUrl: "https://bookmark-landing-page-jade-gamma.vercel.app",
+    repoUrl: "https://github.com/robcrock/bookmark-landing-page",
     link: "https://www.frontendmentor.io/solutions/bookmark-landing-page-9Cv_AE_iki",
   },
   {
@@ -46,6 +56,9 @@ export const PROJECTS: Project[] = [
       "This small homepage challenge packs a big punch to test your layout skills. There's also a slider in there to add a JS layer for extra practice.",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/room_homepage.png",
+    slug: "room-homepage",
+    liveUrl: "https://room-homepage-rust-mu.vercel.app",
+    repoUrl: "https://github.com/robcrock/room-homepage",
     link: "https://www.frontendmentor.io/solutions/room-homepage-challenge-hDpuScvD3N",
   },
   {
@@ -54,6 +67,9 @@ export const PROJECTS: Project[] = [
       "This challenge is perfect if you're looking to test your CSS Grid chops. Even without Grid, this project will be a fun one to help you practice your layout skills!",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/loopstudio_landing_page.png",
+    slug: "loopstudio-landing-page",
+    liveUrl: "https://loopstudios-landing-page-lovat.vercel.app",
+    repoUrl: "https://github.com/robcrock/loopstudios-landing-page",
     link: "https://www.frontendmentor.io/solutions/loopstudio-landing-page-JUIE31Bv1F",
   },
   {
@@ -62,6 +78,9 @@ export const PROJECTS: Project[] = [
       "This HTML & CSS only challenge is perfect for anyone just starting out or anyone wanting a small project to play around with.",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/nft_preview_card.png",
+    slug: "nft-card-component",
+    liveUrl: "https://nft-preview-card-beta-kohl.vercel.app",
+    repoUrl: "https://github.com/robcrock/nft-preview-card",
     link: "https://www.frontendmentor.io/solutions/nft-card-component-zlC2SsaeJs",
   },
   {
@@ -70,6 +89,9 @@ export const PROJECTS: Project[] = [
       "This app will be an excellent test of your HTML, CSS, and JS skills. You'll build custom form controls and use JavaScript to generate random passwords.",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/password_generator_app.png",
+    slug: "password-generator-app",
+    liveUrl: "https://password-generator-six-alpha.vercel.app",
+    repoUrl: "https://github.com/robcrock/password-generator",
     link: "https://www.frontendmentor.io/solutions/password-generator-VW-IC174JO",
   },
   {
@@ -78,6 +100,9 @@ export const PROJECTS: Project[] = [
       "This app will test your skills (as well as your knowledge!) as you build out a fully functional quiz. We provide a local JSON file to help you practice working with JSON!",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/frontend_quiz_app.png",
+    slug: "frontend-quiz-app",
+    liveUrl: "https://quiz-app-jet-three.vercel.app",
+    repoUrl: "https://github.com/robcrock/quiz-app",
     link: "https://www.frontendmentor.io/solutions/quiz-app-solution-PcNwlo7VyW",
   },
   {
@@ -86,6 +111,9 @@ export const PROJECTS: Project[] = [
       "This small app is perfect for anyone starting to get to grips with JavaScript. The calculator functionality will be a nice test!",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/tip_calculator_app.png",
+    slug: "tip-calculator-app",
+    liveUrl: "https://tip-calculator-pearl-iota.vercel.app",
+    repoUrl: "https://github.com/robcrock/tip-calculator",
     link: "https://www.frontendmentor.io/solutions/tip-calculator-5XprC0QSFe",
   },
   {
@@ -94,6 +122,9 @@ export const PROJECTS: Project[] = [
       "A perfect opportunity to practice your CSS Grid skills. For anyone wanting to take it up a notch, we provide a JSON data file to practice working with data.",
     tags: ["Next.js", "Tailwind", "Shadcn"],
     image: "/images/featured-projects/time_tracking_dashboard.png",
+    slug: "time-tracking-dashboard",
+    liveUrl: "https://time-tracking-dashboard-three-phi.vercel.app",
+    repoUrl: "https://github.com/robcrock/time-tracking-dashboard",
     link: "https://www.frontendmentor.io/solutions/time-tracking-dashboard-solution-q42DUSOvk5",
   },
 ];


### PR DESCRIPTION
Project thumbnails previously linked out to Frontend Mentor solution pages. They now route to on-site /projects/[slug] detail pages that embed each project's live Vercel deployment in an iframe, so visitors experience the built site without leaving the portfolio.

- constants.ts: add slug/liveUrl/repoUrl to Project and all 8 entries
- both project grids: link internally, drop target=_blank/external badge, add view-transition name for a thumbnail->detail morph
- new /projects/[slug] page mirroring the Lab detail pattern: framed SandboxFrame embed, "open full site" + GitHub links, prev/next nav
- SandboxFrame: optional sandbox prop (forms/popups for interactive demos)
- verify-projects-detail.mjs: Playwright end-to-end checks (all pass)